### PR TITLE
Implement LRU for cache expiry when quota exceeded

### DIFF
--- a/lscache.js
+++ b/lscache.js
@@ -103,12 +103,16 @@ var lscache = function() {
       catch(e) {
         if (e.name === 'QUOTA_EXCEEDED_ERR' || e.name == 'NS_ERROR_DOM_QUOTA_REACHED') {
           // if we fail and there's nothing in localstorage, then
-          // there is simply too much trying to be stored
+          // there is simply too much trying to be stored (> 5mb) and we fail it quietly
           if (storedKeys.length === 0 && !firstTry) {
-            throw new Error("Object with size of "+(key.length + value.length)+" is too large for localStorage");
+            localStorage.removeItem(touchedKey(key));
+            localStorage.removeItem(expirationKey(key));
+            localStorage.removeItem(key);
+            return false;
           }
           
-          // there is logic that happens only on the first failure through
+          // firstTry logic ensures we don't test for size conditions
+          // until the second+ time through
           if (firstTry) {
             firstTry = false;
           }


### PR DESCRIPTION
I took an alternate stab at #3, using an LRU to mimic what memcache does per-slab. The result is a pruning of the oldest-touched items first. The cost tradeoffs are worth considering however:
- we add an additional key for tracking last-touched time. This is partially mitigated by shortening the keys used to -EXP and -LRU, with the added bonus of quick scanning in localStorage
- we add an additional write on access and save to record the last-touched value. This shouldn't hit performance hard, but I suppose if you're going crazy the extra call could cause pain when doing thousands of these ops per second.
- we reduce the clobbering algorithm to do the least number of removals, and therefore retain the highest number of cache hits.
