### PR TITLE
Fix the error handling for the latest version of browsers

### DIFF
--- a/lscache.js
+++ b/lscache.js
@@ -136,7 +136,7 @@ var lscache = function() {
       try {
         setItem(key, value);
       } catch (e) {
-        if (e.name === 'QUOTA_EXCEEDED_ERR' || e.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+        if (e.name === 'QUOTA_EXCEEDED_ERR' || e.name === 'NS_ERROR_DOM_QUOTA_REACHED' || e.name === 'QuotaExceededError') {
           // If we exceeded the quota, then we will sort
           // by the expire time, and then remove the N oldest
           var storedKeys = [];


### PR DESCRIPTION
The error name is now a days `QuotaExceededError` in both Firefox and
Chrome.
