### PR TITLE
Remove useless characters in escapeRegExpSpecialCharacters()

### DIFF
--- a/lscache.js
+++ b/lscache.js
@@ -103,7 +103,7 @@
    * @return {string}
    */
   function escapeRegExpSpecialCharacters(text) {
-    return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+    return text.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
   }
 
   /**


### PR DESCRIPTION
Follow-up to #46.

* `,` `#` `\s` were 100% useless.
* `-` and `/` are only needed when doing some esoteric "Inception-building regex" or "evil eval()". Which is not the case in this code.

References:
* "escapeRegExp" in https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions
* http://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript#3561711
* https://github.com/benjamingr/RegExp.escape/commit/6998be4ac934353da4d8be550b2a052e99acdd24 and [RegExp.escape/data](https://github.com/benjamingr/RegExp.escape/tree/master/data)