### PR TITLE
Fix isOutOfSpace(e) when e is not defined

### DIFF
--- a/lscache.js
+++ b/lscache.js
@@ -91,9 +91,9 @@
 
   // Check to set if the error is us dealing with being out of space
   function isOutOfSpace(e) {
-    if (e && e.name === 'QUOTA_EXCEEDED_ERR' ||
+    if (e && (e.name === 'QUOTA_EXCEEDED_ERR' ||
             e.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
-            e.name === 'QuotaExceededError') {
+            e.name === 'QuotaExceededError')) {
         return true;
     }
     return false;


### PR DESCRIPTION
Operator precedence issue. `e` is checked only for the first `e.name === 'QUOTA_EXCEEDED_ERR'`.