### PR TITLE
Simplify isOutOfSpace() function

### DIFF
--- a/lscache.js
+++ b/lscache.js
@@ -91,12 +91,11 @@
 
   // Check to set if the error is us dealing with being out of space
   function isOutOfSpace(e) {
-    if (e && e.name === 'QUOTA_EXCEEDED_ERR' ||
-            e.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
-            e.name === 'QuotaExceededError') {
-        return true;
-    }
-    return false;
+    return e && (
+      e.name === 'QUOTA_EXCEEDED_ERR' ||
+      e.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+      e.name === 'QuotaExceededError'
+    );
   }
 
   // Determines if native JSON (de-)serialization is supported in the browser.


### PR DESCRIPTION
Simplify a `isOutOfSpace()` function and fix error #74