### PR TITLE
Activate travis for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 12
+  - 10
+  - 8


### PR DESCRIPTION
I thought it might be beneficial to run the tests automatically for lscache.

Before merging this, travis needs to be activated for this repository here: https://travis-ci.com/account/repositories

But that should be all. You can also ping me after it is enabled and I rebase the PR which should trigger travis.