### PR TITLE
Fixes a jsdoc syntax error.

### DIFF
--- a/lscache.js
+++ b/lscache.js
@@ -203,7 +203,7 @@
      * @param {string} key
      * @param {Object|string} value
      * @param {number} time
-     * @return true if the value was inserted successfully
+     * @return {boolean} whether the value was inserted successfully
      */
     set: function(key, value, time) {
       if (!supportsStorage()) return false;


### PR DESCRIPTION
`@return true` ==> `@return {boolean}`.