### PR TITLE
Convert localStorage loop to for-in

### DIFF
--- a/lscache.js
+++ b/lscache.js
@@ -152,6 +152,7 @@
 
   function eachKey(fn) {
     var prefixRegExp = new RegExp('^' + CACHE_PREFIX + escapeRegExpSpecialCharacters(cacheBucket) + '(.*)');
+    var key;
 
     for (key in localStorage) {
       key = key && key.match(prefixRegExp);

--- a/lscache.js
+++ b/lscache.js
@@ -152,9 +152,8 @@
 
   function eachKey(fn) {
     var prefixRegExp = new RegExp('^' + CACHE_PREFIX + escapeRegExpSpecialCharacters(cacheBucket) + '(.*)');
-    // Loop in reverse as removing items will change indices of tail
-    for (var i = localStorage.length-1; i >= 0 ; --i) {
-      var key = localStorage.key(i);
+
+    for (key in localStorage) {
       key = key && key.match(prefixRegExp);
       key = key && key[1];
       if (key && key.indexOf(CACHE_SUFFIX) < 0) {


### PR DESCRIPTION
On Chrome I noticed that `flush` was missing some items, and traced it to the way `eachKey` loops over localStorage.   I observed exactly the problem that reverse iteration is supposed to mitigate: some object keys got missed.  Using for-in fixed it.